### PR TITLE
feat: add filtering and sorting functionality for teams #17

### DIFF
--- a/components/common/teams/teams.tsx
+++ b/components/common/teams/teams.tsx
@@ -1,9 +1,53 @@
 'use client';
 
-import { teams } from '@/mock-data/teams';
+import { teams as allTeams } from '@/mock-data/teams';
 import TeamLine from './team-line';
+import { useTeamsFilterStore } from '@/store/team-filter-store';
+import { useMemo } from 'react';
 
 export default function Teams() {
+   const { filters, sort } = useTeamsFilterStore();
+
+   const displayed = useMemo(() => {
+      let list = allTeams.slice();
+
+      // filter by membership
+      if (filters.membership.length > 0) {
+         const selectedMembership = new Set(filters.membership);
+         list = list.filter((team) =>
+            selectedMembership.has(team.joined ? 'Joined' : 'Not-Joined')
+         );
+      }
+
+      // filter by identifier
+      if (filters.identifier.length > 0) {
+         const selectedIdentifiers = new Set(filters.identifier);
+         list = list.filter((team) => selectedIdentifiers.has(team.id));
+      }
+
+      // sorting
+      const compare = (a: (typeof list)[number], b: (typeof list)[number]) => {
+         switch (sort) {
+            case 'name-asc':
+               return a.name.localeCompare(b.name);
+            case 'name-desc':
+               return b.name.localeCompare(a.name);
+            case 'members-asc':
+               return a.members.length - b.members.length;
+            case 'members-desc':
+               return b.members.length - a.members.length;
+            case 'projects-asc':
+               return a.projects.length - b.projects.length;
+            case 'projects-desc':
+               return b.projects.length - a.projects.length;
+            default:
+               return 0;
+         }
+      };
+
+      return list.sort(compare);
+   }, [filters, sort]);
+
    return (
       <div className="w-full">
          <div className="bg-container px-6 py-1.5 text-sm flex items-center text-muted-foreground border-b sticky top-0 z-10">
@@ -15,7 +59,7 @@ export default function Teams() {
          </div>
 
          <div className="w-full">
-            {teams.map((team) => (
+            {displayed.map((team) => (
                <TeamLine key={team.id} team={team} />
             ))}
          </div>

--- a/components/layout/headers/teams/filter.tsx
+++ b/components/layout/headers/teams/filter.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+   Command,
+   CommandGroup,
+   CommandItem,
+   CommandList,
+   CommandSeparator,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useMemo, useState } from 'react';
+import { ArrowUpDown, CheckIcon, ChevronRight, ListFilter, Shield } from 'lucide-react';
+import { Team, teams } from '@/mock-data/teams';
+import { useTeamsFilterStore } from '@/store/team-filter-store';
+
+type FilterType = 'membership' | 'sort' | 'identifiers';
+
+const Membership: Array<'Joined' | 'Not-Joined'> = ['Joined', 'Not-Joined'];
+
+export function Filter() {
+   const [open, setOpen] = useState(false);
+   const [active, setActive] = useState<FilterType | null>(null);
+
+   const Identifiers: Team['id'][] = useMemo(() => {
+      return teams.map((team) => team.id);
+   }, [teams]);
+
+   const { filters, sort, toggleFilter, clearFilters, getActiveFiltersCount, setSort } =
+      useTeamsFilterStore();
+
+   return (
+      <Popover open={open} onOpenChange={setOpen}>
+         <PopoverTrigger asChild>
+            <Button size="xs" variant="ghost" className="relative">
+               <ListFilter className="size-4 mr-1" />
+               Filter
+               {getActiveFiltersCount() > 0 && (
+                  <span className="absolute -top-1 -right-1 bg-primary text-primary-foreground text-[10px] rounded-full size-4 flex items-center justify-center">
+                     {getActiveFiltersCount()}
+                  </span>
+               )}
+            </Button>
+         </PopoverTrigger>
+         <PopoverContent className="p-0 w-60" align="start">
+            {active === null ? (
+               <Command>
+                  <CommandList>
+                     <CommandGroup>
+                        <CommandItem
+                           onSelect={() => setActive('membership')}
+                           className="flex items-center justify-between cursor-pointer"
+                        >
+                           <span className="flex items-center gap-2">
+                              <Shield className="size-4 text-muted-foreground" />
+                              Members
+                           </span>
+                           <div className="flex items-center">
+                              {filters.membership.length > 0 && (
+                                 <span className="text-xs text-muted-foreground mr-1">
+                                    {filters.membership.length}
+                                 </span>
+                              )}
+                              <ChevronRight className="size-4" />
+                           </div>
+                        </CommandItem>
+                        <CommandItem
+                           onSelect={() => setActive('identifiers')}
+                           className="flex items-center justify-between cursor-pointer"
+                        >
+                           <span className="flex items-center gap-2">
+                              <Shield className="size-4 text-muted-foreground" />
+                              Identifiers
+                           </span>
+                           <div className="flex items-center">
+                              {filters.identifier.length > 0 && (
+                                 <span className="text-xs text-muted-foreground mr-1">
+                                    {filters.identifier.length}
+                                 </span>
+                              )}
+                              <ChevronRight className="size-4" />
+                           </div>
+                        </CommandItem>
+                        <CommandItem
+                           onSelect={() => setActive('sort')}
+                           className="flex items-center justify-between cursor-pointer"
+                        >
+                           <span className="flex items-center gap-2">
+                              <ArrowUpDown className="size-4 text-muted-foreground" />
+                              Sort by
+                           </span>
+                           <ChevronRight className="size-4" />
+                        </CommandItem>
+                     </CommandGroup>
+                     {getActiveFiltersCount() > 0 && (
+                        <>
+                           <CommandSeparator />
+                           <CommandGroup>
+                              <CommandItem
+                                 onSelect={() => clearFilters()}
+                                 className="cursor-pointer"
+                              >
+                                 Clear all filters
+                              </CommandItem>
+                           </CommandGroup>
+                        </>
+                     )}
+                  </CommandList>
+               </Command>
+            ) : active === 'membership' ? (
+               <Command>
+                  <div className="flex items-center border-b p-2">
+                     <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-6"
+                        onClick={() => setActive(null)}
+                     >
+                        <ChevronRight className="size-4 rotate-180" />
+                     </Button>
+                     <span className="ml-2 font-medium">Status</span>
+                  </div>
+                  <CommandList>
+                     <CommandGroup>
+                        {Membership.map((type) => (
+                           <CommandItem
+                              key={type}
+                              value={type}
+                              onSelect={() => toggleFilter('membership', type)}
+                              className="flex items-center justify-between"
+                           >
+                              {type}
+                              {filters.membership.includes(type) && <CheckIcon size={16} />}
+                           </CommandItem>
+                        ))}
+                     </CommandGroup>
+                  </CommandList>
+               </Command>
+            ) : active === 'identifiers' ? (
+               <Command>
+                  <div className="flex items-center border-b p-2">
+                     <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-6"
+                        onClick={() => setActive(null)}
+                     >
+                        <ChevronRight className="size-4 rotate-180" />
+                     </Button>
+                     <span className="ml-2 font-medium">Status</span>
+                  </div>
+                  <CommandList>
+                     <CommandGroup>
+                        {Identifiers.map((id) => (
+                           <CommandItem
+                              key={id}
+                              value={id}
+                              onSelect={() => toggleFilter('identifier', id)}
+                              className="flex items-center justify-between"
+                           >
+                              {id}
+                              {filters.identifier.includes(id) && <CheckIcon size={16} />}
+                           </CommandItem>
+                        ))}
+                     </CommandGroup>
+                  </CommandList>
+               </Command>
+            ) : active === 'sort' ? (
+               <Command>
+                  <div className="flex items-center border-b p-2">
+                     <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-6"
+                        onClick={() => setActive(null)}
+                     >
+                        <ChevronRight className="size-4 rotate-180" />
+                     </Button>
+                     <span className="ml-2 font-medium">Sort by</span>
+                  </div>
+                  <CommandList>
+                     <CommandGroup heading="Name">
+                        <CommandItem
+                           onSelect={() => setSort('name-asc')}
+                           className="flex items-center justify-between"
+                        >
+                           A → Z{sort === 'name-asc' && <CheckIcon size={16} />}
+                        </CommandItem>
+                        <CommandItem
+                           onSelect={() => setSort('name-desc')}
+                           className="flex items-center justify-between"
+                        >
+                           Z → A{sort === 'name-desc' && <CheckIcon size={16} />}
+                        </CommandItem>
+                     </CommandGroup>
+                     <CommandSeparator />
+                     <CommandGroup heading="Members">
+                        <CommandItem
+                           onSelect={() => setSort('members-asc')}
+                           className="flex items-center justify-between"
+                        >
+                           No. of Members (asc)
+                           {sort === 'members-asc' && <CheckIcon size={16} />}
+                        </CommandItem>
+                        <CommandItem
+                           onSelect={() => setSort('members-desc')}
+                           className="flex items-center justify-between"
+                        >
+                           No. of Members (desc)
+                           {sort === 'members-desc' && <CheckIcon size={16} />}
+                        </CommandItem>
+                     </CommandGroup>
+                     <CommandSeparator />
+                     <CommandGroup heading="Projects">
+                        <CommandItem
+                           onSelect={() => setSort('projects-asc')}
+                           className="flex items-center justify-between"
+                        >
+                           No. of Projects (asc)
+                           {sort === 'projects-asc' && <CheckIcon size={16} />}
+                        </CommandItem>
+                        <CommandItem
+                           onSelect={() => setSort('projects-desc')}
+                           className="flex items-center justify-between"
+                        >
+                           No. of Projects (desc)
+                           {sort === 'projects-desc' && <CheckIcon size={16} />}
+                        </CommandItem>
+                     </CommandGroup>
+                  </CommandList>
+               </Command>
+            ) : null}
+         </PopoverContent>
+      </Popover>
+   );
+}

--- a/components/layout/headers/teams/header-options.tsx
+++ b/components/layout/headers/teams/header-options.tsx
@@ -2,14 +2,12 @@
 
 import { Button } from '@/components/ui/button';
 import { ListFilter, SlidersHorizontal } from 'lucide-react';
+import { Filter } from './filter';
 
 export default function HeaderOptions() {
    return (
       <div className="w-full flex justify-between items-center border-b py-1.5 px-6 h-10">
-         <Button size="xs" variant="ghost">
-            <ListFilter className="size-4 mr-1" />
-            Filter
-         </Button>
+         <Filter />
          <Button className="relative" size="xs" variant="secondary">
             <SlidersHorizontal className="size-4 mr-1" />
             Display

--- a/store/team-filter-store.ts
+++ b/store/team-filter-store.ts
@@ -1,0 +1,99 @@
+import { Team } from '@/mock-data/teams';
+import { create } from 'zustand';
+
+export type TeamsSort =
+   | 'name-asc'
+   | 'name-desc'
+   | 'members-asc' //number of members
+   | 'members-desc'
+   | 'projects-asc' //number of projects
+   | 'projects-desc';
+
+export interface TeamsFilterState {
+   filters: {
+      membership: ('Joined' | 'Not-Joined')[];
+      identifier: Team['id'][];
+   };
+   sort: TeamsSort;
+
+   setSort: (sort: TeamsSort) => void;
+   setFilter: (
+      type: 'membership' | 'identifier',
+      ids: 'Joined' | 'Not-Joined' | Team['id']
+   ) => void;
+   toggleFilter: (
+      type: 'membership' | 'identifier',
+      id: 'Joined' | 'Not-Joined' | Team['id']
+   ) => void;
+   clearFilters: () => void;
+   clearFilterType: (type: 'membership' | 'identifier') => void;
+   hasActiveFilters: () => boolean;
+   getActiveFiltersCount: () => number;
+}
+
+export const useTeamsFilterStore = create<TeamsFilterState>((set, get) => ({
+   filters: {
+      membership: [],
+      identifier: [],
+   },
+   sort: 'name-asc',
+
+   setSort: (sort) => set({ sort }),
+   setFilter: (type, ids) =>
+      set((state) => ({
+         filters: {
+            ...state.filters,
+            [type]: ids as 'Joined' | 'Not-Joined' | Team['id'],
+         },
+      })),
+
+   toggleFilter: (type, id) => {
+      set((state) => {
+         if (type === 'membership') {
+            const current = state.filters.membership;
+            const typedId = id as 'Joined' | 'Not-Joined';
+            const next = current.includes(typedId)
+               ? current.filter((ele) => ele !== typedId)
+               : [...current, typedId];
+
+            return {
+               filters: {
+                  ...state.filters,
+                  membership: next,
+               },
+            };
+         } else {
+            const current = state.filters.identifier;
+            const typedId = id as Team['id'];
+            const next = current.includes(id)
+               ? current.filter((currentId) => currentId !== typedId)
+               : [...current, typedId];
+
+            return {
+               filters: {
+                  ...state.filters,
+                  identifier: next,
+               },
+            };
+         }
+      });
+   },
+   clearFilters: () => set({ filters: { membership: [], identifier: [] } }),
+   clearFilterType: (type) =>
+      set((state) => {
+         return {
+            filters: {
+               ...state.filters,
+               [type]: [],
+            },
+         };
+      }),
+   hasActiveFilters: () => {
+      const { filters } = get();
+      return Object.values(filters).some((arr) => arr.length > 0);
+   },
+   getActiveFiltersCount: () => {
+      const { filters } = get();
+      return Object.values(filters).reduce((sum, arr) => sum + arr.length, 0);
+   },
+}));


### PR DESCRIPTION
PR for #17 

### Title:
Filtering and sorting functionality for Teams.

### Description

Following features are implemented:

Membership: Filter by membership status (Joined/Not Joined)
Identifier: Filter by tags or identifiers
Members: Sort by number of members (Highest to Lowest / Lowest to Highest)
Projects: Sort by number of projects (Highest to Lowest / Lowest to Highest)
Name: Sort alphabetically (A-Z / Z-A)
