### PR TITLE
Add list view issue dragging with column drop and landing overlay

### DIFF
--- a/components/common/issues/all-issues.tsx
+++ b/components/common/issues/all-issues.tsx
@@ -10,6 +10,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { GroupIssues } from './group-issues';
 import { SearchIssues } from './search-issues';
+import { IssueDropLandingOverlay } from './issue-drop-landing-overlay';
 import { CustomDragLayer } from './issue-grid';
 import { cn } from '@/lib/utils';
 import { Issue } from '@/mock-data/issues';
@@ -37,9 +38,13 @@ export default function AllIssues() {
 }
 
 const SearchIssuesView = () => (
-   <div className="px-6 mb-6">
-      <SearchIssues />
-   </div>
+   <DndProvider backend={HTML5Backend}>
+      <CustomDragLayer />
+      <IssueDropLandingOverlay />
+      <div className="px-6 mb-6">
+         <SearchIssues />
+      </div>
+   </DndProvider>
 );
 
 const FilteredIssuesView: FC<{
@@ -69,6 +74,7 @@ const FilteredIssuesView: FC<{
    return (
       <DndProvider backend={HTML5Backend}>
          <CustomDragLayer />
+         <IssueDropLandingOverlay />
          <div className={cn(isViewTypeGrid && 'flex h-full gap-3 px-2 py-2 min-w-max')}>
             {status.map((statusItem) => (
                <GroupIssues
@@ -90,6 +96,7 @@ const GroupIssuesListView: FC<{
    return (
       <DndProvider backend={HTML5Backend}>
          <CustomDragLayer />
+         <IssueDropLandingOverlay />
          <div className={cn(isViewTypeGrid && 'flex h-full gap-3 px-2 py-2 min-w-max')}>
             {status.map((statusItem) => (
                <GroupIssues

--- a/components/common/issues/group-issues.tsx
+++ b/components/common/issues/group-issues.tsx
@@ -4,16 +4,96 @@ import { Issue } from '@/mock-data/issues';
 import { Status } from '@/mock-data/status';
 import { useIssuesStore } from '@/store/issues-store';
 import { useViewStore } from '@/store/view-store';
+import { useIssueDropLandingStore } from '@/store/issue-drop-landing-store';
 import { cn } from '@/lib/utils';
 import { Plus } from 'lucide-react';
 import { FC, useRef } from 'react';
 import { useDrop } from 'react-dnd';
 import { Button } from '../../ui/button';
-import { IssueDragType, IssueGrid } from './issue-grid';
+import { IssueDragType, IssueGrid, type IssueDragItem } from './issue-grid';
 import { IssueLine } from './issue-line';
 import { useCreateIssueStore } from '@/store/create-issue-store';
 import { sortIssuesByPriority } from '@/mock-data/issues';
 import { AnimatePresence, motion } from 'motion/react';
+
+function useStatusColumnDrop(status: Status) {
+   const ref = useRef<HTMLDivElement>(null);
+   const { updateIssueStatus } = useIssuesStore();
+
+   const [{ isOver, canDrop, isSameStatus }, drop] = useDrop<
+      IssueDragItem,
+      void,
+      { isOver: boolean; canDrop: boolean; isSameStatus: boolean }
+   >(() => ({
+      accept: IssueDragType,
+      drop(item, monitor) {
+         const issue = item.issue;
+         if (issue.status.id !== status.id) {
+            const state = useIssueDropLandingStore.getState();
+            const origin =
+               state.dragPreviewOffset ??
+               monitor.getSourceClientOffset() ??
+               monitor.getClientOffset();
+            if (origin) {
+               state.beginLanding({
+                  issueId: issue.id,
+                  issue,
+                  x: origin.x,
+                  y: origin.y,
+                  previewVariant: item.previewVariant,
+               });
+            }
+            updateIssueStatus(issue.id, status);
+         }
+      },
+      collect: (monitor) => {
+         const dragged = monitor.getItem() as IssueDragItem | undefined;
+         const issue = dragged?.issue;
+         return {
+            isOver: monitor.isOver(),
+            canDrop: monitor.canDrop(),
+            isSameStatus: issue ? issue.status.id === status.id : false,
+         };
+      },
+   }));
+   drop(ref);
+
+   const isDropActive = isOver && canDrop && !isSameStatus;
+
+   return { ref, isDropActive };
+}
+
+function StatusColumnDropHighlight({
+   isActive,
+   message,
+   isBoardColumn,
+}: {
+   isActive: boolean;
+   message: string;
+   isBoardColumn: boolean;
+}) {
+   return (
+      <AnimatePresence>
+         {isActive && (
+            <motion.div
+               initial={false}
+               animate={{ opacity: 1 }}
+               exit={{ opacity: 0 }}
+               transition={{ opacity: { duration: 0.08 } }}
+               aria-hidden
+               className={cn(
+                  'pointer-events-none absolute inset-0 z-20 flex items-center justify-center border-2 border-dashed border-ring bg-accent/30 dark:border-sidebar-border dark:bg-sidebar-accent/50',
+                  isBoardColumn && 'rounded-md'
+               )}
+            >
+               <span className="max-w-[90%] rounded-md border border-border bg-card/95 px-3 py-1.5 text-center text-sm font-medium text-foreground shadow-sm dark:border-sidebar-border dark:bg-sidebar dark:text-sidebar-foreground">
+                  {message}
+               </span>
+            </motion.div>
+         )}
+      </AnimatePresence>
+   );
+}
 
 interface GroupIssuesProps {
    status: Status;
@@ -26,16 +106,23 @@ export function GroupIssues({ status, issues, count }: GroupIssuesProps) {
    const isViewTypeGrid = viewType === 'grid';
    const { openModal } = useCreateIssueStore();
    const sortedIssues = sortIssuesByPriority(issues);
+   const { ref: columnRef, isDropActive } = useStatusColumnDrop(status);
 
    return (
       <div
+         ref={columnRef}
          className={cn(
-            'bg-conainer',
+            'bg-conainer relative',
             isViewTypeGrid
                ? 'overflow-hidden rounded-md h-full flex-shrink-0 w-[348px] flex flex-col'
                : ''
          )}
       >
+         <StatusColumnDropHighlight
+            isActive={isDropActive}
+            isBoardColumn={isViewTypeGrid}
+            message={isViewTypeGrid ? 'Release to move here' : 'Release to change status'}
+         />
          <div
             className={cn(
                'sticky top-0 z-10 bg-container w-full',
@@ -74,61 +161,21 @@ export function GroupIssues({ status, issues, count }: GroupIssuesProps) {
          {viewType === 'list' ? (
             <div className="space-y-0">
                {sortedIssues.map((issue) => (
-                  <IssueLine key={issue.id} issue={issue} layoutId={true} />
+                  <IssueLine key={issue.id} issue={issue} />
                ))}
             </div>
          ) : (
-            <IssueGridList issues={issues} status={status} />
+            <IssueGridList issues={issues} />
          )}
       </div>
    );
 }
 
-const IssueGridList: FC<{ issues: Issue[]; status: Status }> = ({ issues, status }) => {
-   const ref = useRef<HTMLDivElement>(null);
-   const { updateIssueStatus } = useIssuesStore();
-
-   // Set up drop functionality to accept only issue items.
-   const [{ isOver }, drop] = useDrop(() => ({
-      accept: IssueDragType,
-      drop(item: Issue, monitor) {
-         if (monitor.didDrop() && item.status.id !== status.id) {
-            updateIssueStatus(item.id, status);
-         }
-      },
-      collect: (monitor) => ({
-         isOver: !!monitor.isOver(),
-      }),
-   }));
-   drop(ref);
-
+const IssueGridList: FC<{ issues: Issue[] }> = ({ issues }) => {
    const sortedIssues = sortIssuesByPriority(issues);
 
    return (
-      <div
-         ref={ref}
-         className="flex-1 h-full overflow-y-auto p-2 space-y-2 bg-zinc-50/50 dark:bg-zinc-900/50 relative"
-      >
-         <AnimatePresence>
-            {isOver && (
-               <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.1 }}
-                  className="fixed top-0 left-0 right-0 bottom-0 z-10 flex items-center justify-center pointer-events-none bg-background/90"
-                  style={{
-                     width: ref.current?.getBoundingClientRect().width || '100%',
-                     height: ref.current?.getBoundingClientRect().height || '100%',
-                     transform: `translate(${ref.current?.getBoundingClientRect().left || 0}px, ${ref.current?.getBoundingClientRect().top || 0}px)`,
-                  }}
-               >
-                  <div className="bg-background border border-border rounded-md p-3 shadow-md max-w-[90%]">
-                     <p className="text-sm font-medium text-center">Board ordered by priority</p>
-                  </div>
-               </motion.div>
-            )}
-         </AnimatePresence>
+      <div className="flex-1 min-h-0 h-full overflow-y-auto p-2 space-y-2 bg-zinc-50/50 dark:bg-zinc-900/50">
          {sortedIssues.map((issue) => (
             <IssueGrid key={issue.id} issue={issue} />
          ))}

--- a/components/common/issues/issue-drop-landing-overlay.tsx
+++ b/components/common/issues/issue-drop-landing-overlay.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useIssueDropLandingStore } from '@/store/issue-drop-landing-store';
+import { useIssuesStore } from '@/store/issues-store';
+import { motion } from 'motion/react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { IssueDragPreviewGrid, IssueDragPreviewList } from './issue-grid';
+
+function listPreviewWidthPx(): number {
+   if (typeof window === 'undefined') return 576;
+   return Math.min(576, window.innerWidth - 24);
+}
+
+export function IssueDropLandingOverlay() {
+   const landing = useIssueDropLandingStore((s) => s.landing);
+   const clearLanding = useIssueDropLandingStore((s) => s.clearLanding);
+   const liveIssue = useIssuesStore((s) =>
+      landing ? s.issues.find((i) => i.id === landing.issueId) : undefined
+   );
+
+   const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+   const landingKeyRef = useRef<string | null>(null);
+
+   const displayIssue = liveIssue ?? landing?.issue;
+
+   const startBox = useMemo(() => {
+      if (!landing) return null;
+      const isList = landing.previewVariant === 'list';
+      return {
+         left: landing.x,
+         top: landing.y,
+         width: isList ? listPreviewWidthPx() : 348,
+         height: isList ? 44 : 168,
+      };
+   }, [landing]);
+
+   useLayoutEffect(() => {
+      if (!landing) {
+         landingKeyRef.current = null;
+         setTargetRect(null);
+         return;
+      }
+
+      const activeLanding = landing;
+      const key = `${activeLanding.issueId}-${activeLanding.x}-${activeLanding.y}`;
+      if (landingKeyRef.current !== key) {
+         landingKeyRef.current = key;
+         setTargetRect(null);
+      }
+
+      let cancelled = false;
+
+      function measure(): boolean {
+         const el = document.querySelector<HTMLElement>(
+            `[data-issue-drop-land="${activeLanding.issueId}"]`
+         );
+         if (!el || cancelled) return false;
+         setTargetRect(el.getBoundingClientRect());
+         return true;
+      }
+
+      if (!measure()) {
+         const id = requestAnimationFrame(() => {
+            if (!cancelled) measure();
+         });
+         return () => {
+            cancelled = true;
+            cancelAnimationFrame(id);
+         };
+      }
+
+      return () => {
+         cancelled = true;
+      };
+   }, [landing]);
+
+   useEffect(() => {
+      if (!landing) return;
+      const t = window.setTimeout(() => {
+         clearLanding();
+      }, 400);
+      return () => window.clearTimeout(t);
+   }, [landing, clearLanding]);
+
+   if (!landing || !startBox || !displayIssue) {
+      return null;
+   }
+
+   const isList = landing.previewVariant === 'list';
+   const landingMountKey = `${landing.issueId}-${landing.x}-${landing.y}`;
+
+   return (
+      <motion.div
+         key={landingMountKey}
+         className="pointer-events-none fixed z-[60] overflow-hidden rounded-md border-2 border-dashed border-ring bg-accent/30 shadow-md dark:border-sidebar-border dark:bg-sidebar-accent/50"
+         initial={{
+            left: startBox.left,
+            top: startBox.top,
+            width: startBox.width,
+            height: startBox.height,
+         }}
+         animate={
+            targetRect
+               ? {
+                    left: targetRect.left,
+                    top: targetRect.top,
+                    width: targetRect.width,
+                    height: targetRect.height,
+                 }
+               : {
+                    left: startBox.left,
+                    top: startBox.top,
+                    width: startBox.width,
+                    height: startBox.height,
+                 }
+         }
+         transition={{
+            left: { type: 'tween', duration: 0.24, ease: [0.25, 0.1, 0.25, 1] },
+            top: { type: 'tween', duration: 0.24, ease: [0.25, 0.1, 0.25, 1] },
+            width: { type: 'tween', duration: 0.24, ease: [0.25, 0.1, 0.25, 1] },
+            height: { type: 'tween', duration: 0.24, ease: [0.25, 0.1, 0.25, 1] },
+         }}
+      >
+         <div className="size-full min-h-0 overflow-hidden [&>*]:h-full [&>*]:min-h-0">
+            {isList ? (
+               <IssueDragPreviewList issue={displayIssue} />
+            ) : (
+               <IssueDragPreviewGrid issue={displayIssue} />
+            )}
+         </div>
+      </motion.div>
+   );
+}

--- a/components/common/issues/issue-grid.tsx
+++ b/components/common/issues/issue-grid.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { Issue } from '@/mock-data/issues';
+import { priorities } from '@/mock-data/priorities';
+import { status as statusCatalog } from '@/mock-data/status';
 import { format } from 'date-fns';
 import { motion } from 'motion/react';
 import { useEffect, useRef } from 'react';
-import { DragSourceMonitor, useDrag, useDragLayer, useDrop } from 'react-dnd';
+import { DragSourceMonitor, useDrag, useDragLayer } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
+import { GripVertical } from 'lucide-react';
 import { AssigneeUser } from './assignee-user';
 import { LabelBadge } from './label-badge';
 import { PrioritySelector } from './priority-selector';
@@ -13,14 +16,20 @@ import { ProjectBadge } from './project-badge';
 import { StatusSelector } from './status-selector';
 import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu';
 import { IssueContextMenu } from './issue-context-menu';
+import { useIssueDropLandingStore } from '@/store/issue-drop-landing-store';
 
 export const IssueDragType = 'ISSUE';
+
+export interface IssueDragItem {
+   issue: Issue;
+   previewVariant: 'list' | 'grid';
+}
+
 type IssueGridProps = {
    issue: Issue;
 };
 
-// Custom DragLayer component to render the drag preview
-function IssueDragPreview({ issue }: { issue: Issue }) {
+export function IssueDragPreviewGrid({ issue }: { issue: Issue }) {
    return (
       <div className="w-full p-3 bg-background rounded-md border border-border/50 overflow-hidden">
          <div className="flex items-center justify-between mb-2">
@@ -48,66 +57,109 @@ function IssueDragPreview({ issue }: { issue: Issue }) {
    );
 }
 
+export function IssueDragPreviewList({ issue }: { issue: Issue }) {
+   const priorityFromCatalog = priorities.find((p) => p.id === issue.priority.id);
+   const PriorityIcon = priorityFromCatalog?.icon ?? issue.priority.icon;
+   const statusFromCatalog = statusCatalog.find((s) => s.id === issue.status.id);
+   const statusColor = statusFromCatalog?.color ?? issue.status.color ?? '#94a3b8';
+   const statusName = statusFromCatalog?.name ?? issue.status.name;
+
+   return (
+      <div className="flex h-11 w-full items-center gap-2 rounded-md border border-border/50 bg-background px-2 pr-4 shadow-sm">
+         <GripVertical className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+         {PriorityIcon ? (
+            <PriorityIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+         ) : (
+            <span className="size-3.5 shrink-0 rounded-sm bg-muted" aria-hidden />
+         )}
+         <span className="w-[4.5rem] shrink-0 truncate text-xs font-medium text-muted-foreground sm:w-[4.125rem]">
+            {issue.identifier}
+         </span>
+         <span
+            className="size-2 shrink-0 rounded-full border border-border/60"
+            style={{ backgroundColor: statusColor }}
+            title={statusName}
+         />
+         <span className="min-w-0 flex-1 truncate text-sm font-medium">{issue.title}</span>
+         <span className="shrink-0 text-xs text-muted-foreground">
+            {format(new Date(issue.createdAt), 'MMM dd')}
+         </span>
+      </div>
+   );
+}
+
 // Custom DragLayer to show custom preview during drag
 export function CustomDragLayer() {
+   const setDragPreviewOffset = useIssueDropLandingStore((s) => s.setDragPreviewOffset);
+
    const { itemType, isDragging, item, currentOffset } = useDragLayer((monitor) => ({
-      item: monitor.getItem() as Issue,
+      item: monitor.getItem() as IssueDragItem | null,
       itemType: monitor.getItemType(),
       currentOffset: monitor.getSourceClientOffset(),
       isDragging: monitor.isDragging(),
    }));
 
-   if (!isDragging || itemType !== IssueDragType || !currentOffset) {
+   useEffect(() => {
+      if (isDragging && currentOffset) {
+         setDragPreviewOffset({ x: currentOffset.x, y: currentOffset.y });
+      }
+   }, [isDragging, currentOffset, setDragPreviewOffset]);
+
+   if (!isDragging || itemType !== IssueDragType || !currentOffset || !item?.issue) {
       return null;
    }
+
+   const { issue, previewVariant } = item;
+   const isListPreview = previewVariant === 'list';
 
    return (
       <div
          className="fixed pointer-events-none z-50 left-0 top-0"
          style={{
             transform: `translate(${currentOffset.x}px, ${currentOffset.y}px)`,
-            width: '348px', // Match the width of your cards
+            width: isListPreview ? 'min(36rem, calc(100vw - 1.5rem))' : '348px',
          }}
       >
-         <IssueDragPreview issue={item} />
+         {isListPreview ? (
+            <IssueDragPreviewList issue={issue} />
+         ) : (
+            <IssueDragPreviewGrid issue={issue} />
+         )}
       </div>
    );
 }
 
 export function IssueGrid({ issue }: IssueGridProps) {
    const ref = useRef<HTMLDivElement>(null);
+   const isLandingTarget = useIssueDropLandingStore((s) => s.landing?.issueId === issue.id);
 
-   // Set up drag functionality.
-   const [{ isDragging }, drag, preview] = useDrag(() => ({
+   const [{ isDragging }, drag, preview] = useDrag<
+      IssueDragItem,
+      unknown,
+      { isDragging: boolean }
+   >(() => ({
       type: IssueDragType,
-      item: issue,
+      item: { issue, previewVariant: 'grid' },
       collect: (monitor: DragSourceMonitor) => ({
          isDragging: monitor.isDragging(),
       }),
    }));
 
-   // Use empty image as drag preview (we'll create a custom one with DragLayer)
    useEffect(() => {
       preview(getEmptyImage(), { captureDraggingState: true });
    }, [preview]);
 
-   // Set up drop functionality.
-   const [, drop] = useDrop(() => ({
-      accept: IssueDragType,
-   }));
-
-   // Connect drag and drop to the element.
-   drag(drop(ref));
+   drag(ref);
 
    return (
       <ContextMenu>
          <ContextMenuTrigger asChild>
             <motion.div
                ref={ref}
+               data-issue-drop-land={issue.id}
                className="w-full p-3 bg-background rounded-md shadow-xs border border-border/50 cursor-default"
-               layoutId={`issue-grid-${issue.identifier}`}
                style={{
-                  opacity: isDragging ? 0.5 : 1,
+                  opacity: isLandingTarget ? 0 : isDragging ? 0.5 : 1,
                   cursor: isDragging ? 'grabbing' : 'default',
                }}
             >

--- a/components/common/issues/issue-line.tsx
+++ b/components/common/issues/issue-line.tsx
@@ -7,32 +7,73 @@ import { LabelBadge } from './label-badge';
 import { PrioritySelector } from './priority-selector';
 import { ProjectBadge } from './project-badge';
 import { StatusSelector } from './status-selector';
+import { IssueDragType, type IssueDragItem } from './issue-grid';
 import { motion } from 'motion/react';
+import { GripVertical } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { DragSourceMonitor, useDrag } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
 
 import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu';
 import { IssueContextMenu } from './issue-context-menu';
+import { useIssueDropLandingStore } from '@/store/issue-drop-landing-store';
+import { cn } from '@/lib/utils';
 
-export function IssueLine({ issue, layoutId = false }: { issue: Issue; layoutId?: boolean }) {
+export function IssueLine({ issue }: { issue: Issue }) {
+   const isLandingTarget = useIssueDropLandingStore((s) => s.landing?.issueId === issue.id);
+   const dragHandleRef = useRef<HTMLButtonElement>(null);
+
+   const [{ isDragging }, drag, preview] = useDrag<
+      IssueDragItem,
+      unknown,
+      { isDragging: boolean }
+   >(() => ({
+      type: IssueDragType,
+      item: { issue, previewVariant: 'list' },
+      collect: (monitor: DragSourceMonitor) => ({
+         isDragging: monitor.isDragging(),
+      }),
+   }));
+
+   useEffect(() => {
+      preview(getEmptyImage(), { captureDraggingState: true });
+   }, [preview]);
+
+   drag(dragHandleRef);
+
    return (
       <ContextMenu>
          <ContextMenuTrigger asChild>
             <motion.div
-               {...(layoutId && { layoutId: `issue-line-${issue.identifier}` })}
-               //href={`/lndev-ui/issue/${issue.identifier}`}
-               className="w-full flex items-center justify-start h-11 px-6 hover:bg-sidebar/50"
+               data-issue-drop-land={issue.id}
+               className={cn(
+                  'w-full flex items-center justify-start h-11 pl-2 pr-6 hover:bg-sidebar/50',
+                  isDragging && 'opacity-50',
+                  isLandingTarget && 'opacity-0'
+               )}
             >
-               <div className="flex items-center gap-0.5">
+               <button
+                  ref={dragHandleRef}
+                  type="button"
+                  aria-label={`Drag to move ${issue.identifier}`}
+                  className="flex shrink-0 items-center justify-center rounded p-1 text-muted-foreground hover:bg-sidebar/80 hover:text-foreground cursor-grab active:cursor-grabbing touch-none"
+                  onClick={(e) => e.stopPropagation()}
+                  onPointerDown={(e) => e.stopPropagation()}
+               >
+                  <GripVertical className="size-4" aria-hidden />
+               </button>
+               <div className="flex min-w-0 flex-1 items-center gap-0.5">
                   <PrioritySelector priority={issue.priority} issueId={issue.id} />
                   <span className="text-sm hidden sm:inline-block text-muted-foreground font-medium w-[66px] truncate shrink-0 mr-0.5">
                      {issue.identifier}
                   </span>
                   <StatusSelector status={issue.status} issueId={issue.id} />
-               </div>
-               <span className="min-w-0 flex items-center justify-start mr-1 ml-0.5">
-                  <span className="text-xs sm:text-sm font-medium sm:font-semibold truncate">
-                     {issue.title}
+                  <span className="min-w-0 flex flex-1 items-center justify-start mr-1 ml-0.5">
+                     <span className="text-xs sm:text-sm font-medium sm:font-semibold truncate">
+                        {issue.title}
+                     </span>
                   </span>
-               </span>
+               </div>
                <div className="flex items-center justify-end gap-2 ml-auto sm:w-fit">
                   <div className="w-3 shrink-0"></div>
                   <div className="-space-x-5 hover:space-x-1 lg:space-x-1 items-center justify-end hidden sm:flex duration-200 transition-all">

--- a/components/common/issues/search-issues.tsx
+++ b/components/common/issues/search-issues.tsx
@@ -37,7 +37,7 @@ export function SearchIssues() {
                      </div>
                      <div className="divide-y">
                         {searchResults.map((issue) => (
-                           <IssueLine key={issue.id} issue={issue} layoutId={false} />
+                           <IssueLine key={issue.id} issue={issue} />
                         ))}
                      </div>
                   </div>

--- a/store/issue-drop-landing-store.ts
+++ b/store/issue-drop-landing-store.ts
@@ -1,0 +1,27 @@
+import type { Issue } from '@/mock-data/issues';
+import { create } from 'zustand';
+
+export interface IssueDropLanding {
+   issueId: string;
+   issue: Issue;
+   x: number;
+   y: number;
+   previewVariant: 'list' | 'grid';
+}
+
+interface IssueDropLandingState {
+   landing: IssueDropLanding | null;
+   /** Last CustomDragLayer position (matches on-screen preview). */
+   dragPreviewOffset: { x: number; y: number } | null;
+   setDragPreviewOffset: (offset: { x: number; y: number } | null) => void;
+   beginLanding: (landing: IssueDropLanding) => void;
+   clearLanding: () => void;
+}
+
+export const useIssueDropLandingStore = create<IssueDropLandingState>((set) => ({
+   landing: null,
+   dragPreviewOffset: null,
+   setDragPreviewOffset: (dragPreviewOffset) => set({ dragPreviewOffset }),
+   beginLanding: (landing) => set({ landing }),
+   clearLanding: () => set({ landing: null, dragPreviewOffset: null }),
+}));


### PR DESCRIPTION
- Drag list rows via grip handle; custom drag layer for list/grid previews
- Column-level drop with highlight; landing animation to target row/card
- Zustand store for landing state; overlay in search, filtered, and default views
- Simplify board grid list (drop on column only)

Made-with: Cursor